### PR TITLE
Fixes

### DIFF
--- a/Russian/main/MiRecycle.apk/res/values-ru/strings.xml
+++ b/Russian/main/MiRecycle.apk/res/values-ru/strings.xml
@@ -21,6 +21,7 @@
     <string name="abc_toolbar_collapse_description">Свернуть</string>
     <string name="search_menu_title">Поиск</string>
     <string name="status_bar_notification_info_overflow">>999</string>
+    <string name="btn_check_back">Назад</string>
     <string name="hardware_detection">Тестирование устройства</string>
     <string name="item_name_battery">Батарея</string>
     <string name="item_name_bluetooth">Bluetooth</string>

--- a/Russian/main/SecurityCenter.apk/res/values-ru/strings.xml
+++ b/Russian/main/SecurityCenter.apk/res/values-ru/strings.xml
@@ -1110,7 +1110,7 @@
     <string name="deep_power_save_item_summary_lock_screen_time">Отключить экран через 30 секунд бездействия для экономии батареи</string>
     <string name="power_save_mode_enable">Экономия батареи</string>
     <string name="power_save_mode_summary">Ограничивать фоновую активность и отключать синхронизацию</string>
-    <string name="power_optimize_save_mode_not_opened">Включить экономию батареи</string>
+    <string name="power_optimize_save_mode_not_opened">Включение экономии батареи</string>
     <string name="notification_exit_power_save_mode">Экономия батареи отключена</string>
     <string name="notification_exit_power_save_mode_subtitle">Заряд батареи %s</string>
     <string name="power_save_mode_auto_exit_title">Отключать автоматически</string>

--- a/Russian/main/SecurityCenter.apk/res/values-ru/strings.xml
+++ b/Russian/main/SecurityCenter.apk/res/values-ru/strings.xml
@@ -1110,7 +1110,7 @@
     <string name="deep_power_save_item_summary_lock_screen_time">Отключить экран через 30 секунд бездействия для экономии батареи</string>
     <string name="power_save_mode_enable">Экономия батареи</string>
     <string name="power_save_mode_summary">Ограничивать фоновую активность и отключать синхронизацию</string>
-    <string name="power_optimize_save_mode_not_opened">Отключение экономии батареи</string>
+    <string name="power_optimize_save_mode_not_opened">Включить экономию батареи</string>
     <string name="notification_exit_power_save_mode">Экономия батареи отключена</string>
     <string name="notification_exit_power_save_mode_subtitle">Заряд батареи %s</string>
     <string name="power_save_mode_auto_exit_title">Отключать автоматически</string>


### PR DESCRIPTION
Некорректное описание действия. Функция `Экономия батареи` наоборот, включается применением, так что сделал более корректный перевод.

![img_20190113_114811](https://user-images.githubusercontent.com/42800753/51083905-5003c380-172a-11e9-8120-777072bca073.jpg)

Добавление одной дополнительной строки для перевода `Back`.

![screenshot_2019-01-13-11-56-01-379_com xiaomi mirecycle](https://user-images.githubusercontent.com/42800753/51083907-509c5a00-172a-11e9-8a09-277eef5c012c.png)
